### PR TITLE
Add <stdexcept> to make project compilable

### DIFF
--- a/library/game/game_map.cpp
+++ b/library/game/game_map.cpp
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <cmath>
 #include <string>
+#include <stdexcept>
 
 TGameMap LoadPlanarGraph(int maxDistBetweenPlanets, std::function<int()> readInt) {
     TGameMap gameMap;


### PR DESCRIPTION
Without it, building fails with the following error:

```
/path/to/Auralux/library/game/game_map.cpp: В функции «TGameMap LoadPlanarGraph(int, std::function<int()>)»:                                                
/path/to/Auralux/library/game/game_map.cpp:37:28: ошибка: «runtime_error» не является элементом «std»                                                       
   37 |                 throw std::runtime_error(                               
      |                            ^~~~~~~~~~~~~                                
make[2]: *** [CMakeFiles/tournament_runner.dir/build.make:146: CMakeFiles/tournament_runner.dir/library/game/game_map.cpp.o] Ошибка 1                           
make[1]: *** [CMakeFiles/Makefile2:122: CMakeFiles/tournament_runner.dir/all] Ошибка 2                                                                          
make: *** [Makefile:91: all] Ошибка 2```